### PR TITLE
fix: Resolve segfault and improve thread safety in logger bridge

### DIFF
--- a/include/cql/historic_logger_bridge.hpp
+++ b/include/cql/historic_logger_bridge.hpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <iomanip>
 #include <chrono>
+#include <atomic>
 
 namespace cql {
 
@@ -69,9 +70,9 @@ private:
     std::string m_log_file_path;
     
     // Level enablement - matches historic Logger behavior
-    bool m_enabled_levels[5] = {true, true, true, true, true}; // INFO, NORMAL, DEBUG, ERROR, CRITICAL
-    bool m_file_output_enabled = true;
-    bool m_stderr_enabled = true;
+    std::atomic<bool> m_enabled_levels[5] = {true, true, true, true, true}; // INFO, NORMAL, DEBUG, ERROR, CRITICAL
+    std::atomic<bool> m_file_output_enabled = true;
+    std::atomic<bool> m_stderr_enabled = true;
     
     /**
      * @brief Convert new LogLevel to historic LogLevel index

--- a/include/cql/logger_bridge.hpp
+++ b/include/cql/logger_bridge.hpp
@@ -46,6 +46,9 @@ private:
     // Track whether we initialized our own historic bridge
     inline static bool m_owns_logger_manager = false;
     
+    // Track stderr state locally for thread safety
+    mutable std::atomic<bool> m_stderr_enabled_cache{true};
+    
     // Constructor is private to control instantiation
     explicit LoggerBridge(const std::string& path);
 

--- a/include/cql/logger_bridge.hpp
+++ b/include/cql/logger_bridge.hpp
@@ -49,6 +49,9 @@ private:
     // Track stderr state locally for thread safety
     mutable std::atomic<bool> m_stderr_enabled_cache{true};
     
+    // Track level enablement state locally for thread safety
+    mutable std::atomic<bool> m_level_enabled_cache[5] = {true, true, true, true, true}; // INFO, NORMAL, DEBUG, ERROR, CRITICAL
+    
     // Constructor is private to control instantiation
     explicit LoggerBridge(const std::string& path);
 
@@ -177,6 +180,9 @@ private:
     
     // Get the HistoricLoggerBridge from LoggerManager (if it exists)
     static HistoricLoggerBridge* get_historic_bridge();
+    
+    // Helper to convert HistoricLogLevel to cache array index
+    static size_t historic_level_to_index(HistoricLogLevel level);
 };
 
 // Convert historic LogLevel enum to new LogLevel enum


### PR DESCRIPTION
## Summary
Fixes segmentation fault and improves thread safety in the HistoricLoggerBridge implementation.

## Issues Fixed
- Segmentation fault during concurrent singleton access tests
- File creation failures causing crashes
- Thread safety issues with non-atomic member variables

## Changes
- Made member variables (`m_enabled_levels`, `m_file_output_enabled`, `m_stderr_enabled`) atomic to prevent race conditions
- Modified constructor to gracefully handle file creation failures without throwing exceptions
- Added exception handling in `write_log_message_historic` to prevent crashes during file I/O
- Simplified `isStderrEnabled` to avoid const-correctness issues
- Creates parent directories if they don't exist for log files

## Testing
- Fixed segfault in `LoggerBridgeTest.ConcurrentSingletonAccess`
- All single-threaded tests pass successfully
- Multi-threaded tests show improved stability (though some mutex issues remain under investigation)

## Note
There are still some mutex lock failures occurring in high-concurrency scenarios that need further investigation. These don't cause crashes but do result in error messages. A follow-up PR may be needed for complete resolution.

🤖 Generated with [Claude Code](https://claude.ai/code)