### PR TITLE
feat: Add --version flag to display version information

### DIFF
--- a/src/cql/application_controller.cpp
+++ b/src/cql/application_controller.cpp
@@ -68,6 +68,15 @@ int ApplicationController::handle_file_processing(const std::string& input_file,
 }
 
 int ApplicationController::run(int argc, char* argv[]) {
+    // Check for --version flag early, before any logging
+    if (argc > 1) {
+        std::string first_arg = argv[1];
+        if (first_arg == "--version" || first_arg == "-v") {
+            std::cout << "Claude Query Language (CQL) Compiler v" << CQL_VERSION_STRING << " (" << CQL_BUILD_TIMESTAMP << ")" << std::endl;
+            return CQL_NO_ERROR;
+        }
+    }
+    
     // Create command line handler
     CommandLineHandler cmd_handler(argc, argv);
     

--- a/src/cql/command_line_handler.cpp
+++ b/src/cql/command_line_handler.cpp
@@ -110,6 +110,7 @@ void CommandLineHandler::print_help() {
               << "Usage: cql [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]\n\n"
               << "Options:\n"
               << "  --help, -h              Show this help information\n"
+              << "  --version, -v           Show version information\n"
               << "  --interactive, -i       Run in interactive mode\n"
               << "  --clipboard, -c         Copy output to clipboard instead of writing to a file\n"
               << "  --include-header        Include compiler headers and status messages in output\n"


### PR DESCRIPTION
## Summary
- Added `--version` and `-v` command-line flags to display version information
- Version output shows only the version string without any logging messages
- Flag is processed early in the application flow to ensure clean output

## Changes
- Modified `application_controller.cpp` to check for version flag before logger initialization
- Updated help text in `command_line_handler.cpp` to document the new flag

## Test Plan
- [x] Built the project successfully
- [x] Tested `./cql --version` outputs clean version string
- [x] Tested `./cql -v` outputs clean version string  
- [x] Verified no logging messages appear before version output
- [x] Confirmed help text includes the new option

## Example Output
```
$ ./cql --version
Claude Query Language (CQL) Compiler v0.1.0 (Aug 30 2025 11:14:21)
```

🤖 Generated with [Claude Code](https://claude.ai/code)