### PR TITLE
fix: Handle null stop_sequence in Anthropic API response parsing

### DIFF
--- a/lib/ailib/src/providers/anthropic.cpp
+++ b/lib/ailib/src/providers/anthropic.cpp
@@ -437,7 +437,13 @@ ProviderResponse AnthropicProvider::parse_response(const nlohmann::json& json_re
         // Extract additional metadata
         response.metadata["id"] = json_response.value("id", "");
         response.metadata["stop_reason"] = json_response.value("stop_reason", "");
-        response.metadata["stop_sequence"] = json_response.value("stop_sequence", "");
+        
+        // Handle stop_sequence which can be null
+        if (json_response.contains("stop_sequence") && !json_response["stop_sequence"].is_null()) {
+            response.metadata["stop_sequence"] = json_response["stop_sequence"].get<std::string>();
+        } else {
+            response.metadata["stop_sequence"] = "";
+        }
         Logger::getInstance().log(LogLevel::DEBUG, "Extracted metadata - id: ", response.metadata["id"],
             ", stop_reason: ", response.metadata["stop_reason"]);
         


### PR DESCRIPTION
## Summary
- Fixed JSON parsing error when Anthropic API returns `"stop_sequence": null`
- Added proper null check before extracting stop_sequence as string
- Enables all live integration tests to pass successfully

## Problem
The Anthropic API sometimes returns `"stop_sequence": null` in responses, but our code was trying to extract it directly as a string, causing:
```
[json.exception.type_error.302] type must be string, but is null
```

## Solution
Added null check before string extraction:
```cpp
// Handle stop_sequence which can be null
if (json_response.contains("stop_sequence") && !json_response["stop_sequence"].is_null()) {
    response.metadata["stop_sequence"] = json_response["stop_sequence"].get<std::string>();
} else {
    response.metadata["stop_sequence"] = "";
}
```

## Test Plan
- [x] All 7 live integration tests now pass with real Anthropic API
- [x] Basic connectivity test works
- [x] Cost estimation test works  
- [x] Conversation handling works
- [x] Async requests work
- [x] Request validation works
- [x] Retry logic works

🤖 Generated with [Claude Code](https://claude.ai/code)