### PR TITLE
fix: Remove debug logging from normal CLI operations

### DIFF
--- a/include/cql/logger_adapters.hpp
+++ b/include/cql/logger_adapters.hpp
@@ -173,7 +173,7 @@ public:
 private:
     std::ofstream m_file;
     std::mutex m_file_mutex;
-    LogLevel m_min_level{LogLevel::DEBUG};
+    LogLevel m_min_level{LogLevel::NORMAL};
     bool m_auto_flush{true};
     
     std::string format_message(LogLevel level, const std::string& message) const;

--- a/include/cql/logger_interface.hpp
+++ b/include/cql/logger_interface.hpp
@@ -110,7 +110,7 @@ public:
     void set_colored_output(bool enable);
     
 private:
-    LogLevel m_min_level{LogLevel::DEBUG};
+    LogLevel m_min_level{LogLevel::NORMAL};
     bool m_colored_output{true};
     
     std::string format_message(LogLevel level, const std::string& message) const;

--- a/src/cql/application_controller.cpp
+++ b/src/cql/application_controller.cpp
@@ -30,13 +30,11 @@ int ApplicationController::handle_file_processing(const std::string& input_file,
                                                   bool include_header) {
     if (use_clipboard) {
         try {
-            Logger::getInstance().log(LogLevel::INFO, "Processing file: ", input_file);
             std::cout << "Processing file: " << input_file << std::endl;
 
             // Copy to clipboard
             if (const std::string result = QueryProcessor::compile_file(input_file); util::copy_to_clipboard(result)) {
                 std::cout << "Compiled query copied to clipboard" << std::endl;
-                Logger::getInstance().log(LogLevel::INFO, "Compiled query copied to clipboard");
             } else {
                 std::cerr << "Failed to copy to clipboard" << std::endl;
                 Logger::getInstance().log(LogLevel::ERROR, "Failed to copy to clipboard");
@@ -81,7 +79,7 @@ int ApplicationController::run(int argc, char* argv[]) {
     CommandLineHandler cmd_handler(argc, argv);
     
     // Default debug level
-    auto debug_level = LogLevel::DEBUG;
+    auto debug_level = LogLevel::NORMAL;
     
     // Check for debug level in arguments
     std::string debug_level_str;
@@ -101,14 +99,18 @@ int ApplicationController::run(int argc, char* argv[]) {
     if (include_headers) {
         std::cout << "Starting CQL Compiler v" << CQL_VERSION_STRING << " (" << CQL_BUILD_TIMESTAMP << ")..." << std::endl;
     }
-    logger.log(LogLevel::INFO, "Starting CQL Compiler v", CQL_VERSION_STRING, " (", CQL_BUILD_TIMESTAMP, ")...");
     
-    // Log the debug level that was set
-    const std::string level_name = debug_level == LogLevel::INFO ? "INFO" :
-                             debug_level == LogLevel::NORMAL ? "NORMAL" : 
-                             debug_level == LogLevel::DEBUG ? "DEBUG" : 
-                             debug_level == LogLevel::ERROR ? "ERROR" : "CRITICAL";
-    logger.log(LogLevel::INFO, "Log level set to: ", level_name);
+    // Only log startup info if headers are requested or debug level is explicitly set
+    if (include_headers || !debug_level_str.empty()) {
+        logger.log(LogLevel::INFO, "Starting CQL Compiler v", CQL_VERSION_STRING, " (", CQL_BUILD_TIMESTAMP, ")...");
+        
+        // Log the debug level that was set
+        const std::string level_name = debug_level == LogLevel::INFO ? "INFO" :
+                                 debug_level == LogLevel::NORMAL ? "NORMAL" : 
+                                 debug_level == LogLevel::DEBUG ? "DEBUG" : 
+                                 debug_level == LogLevel::ERROR ? "ERROR" : "CRITICAL";
+        logger.log(LogLevel::INFO, "Log level set to: ", level_name);
+    }
 
     // Get updated argc/argv after removing debug option
     int effective_argc = cmd_handler.get_argc();

--- a/src/cql/cli.cpp
+++ b/src/cql/cli.cpp
@@ -1128,10 +1128,8 @@ void run_interactive() {
 // process a query file
 bool process_file(const std::string& input_file, const std::string& output_file, bool include_header) {
     try {
-        Logger::getInstance().log(LogLevel::INFO, "Processing file: ", input_file);
-        if (include_header) {
-            std::cout << "Processing file: " << input_file << std::endl;
-        }
+        // Always show which file is being processed - useful for users
+        std::cout << "Processing file: " << input_file << std::endl;
 
         const std::string result = QueryProcessor::compile_file(input_file);
 


### PR DESCRIPTION
## Summary
- Removed debug/info logging that was leaking into normal CLI output
- Changed default log level from DEBUG to NORMAL
- Preserved user-friendly feedback messages

## Changes
- Changed default `LogLevel` from `DEBUG` to `NORMAL` in:
  - `logger_interface.hpp` - DefaultConsoleLogger
  - `logger_adapters.hpp` - FileLogger
  - `application_controller.cpp` - Application default
  
- Removed INFO level logging from file processing while keeping std::cout messages
- Made startup logging conditional (only when `--include-header` or `--debug-level` are used)

## Test Results
- ✅ `cql --help` shows clean help output without debug messages
- ✅ File processing shows only user-friendly "Processing file:" message
- ✅ ERROR level logs still appear appropriately when errors occur
- ✅ Debug logging available when explicitly requested via `--debug-level`

## Before
```
2025-09-01 20:08:28.541 UTC [INFO] [Thread:0x208ab60c0] Starting CQL Compiler v0.1.0...
2025-09-01 20:08:28.543 UTC [INFO] [Thread:0x208ab60c0] Log level set to: DEBUG
Claude Query Language (CQL) Compiler v0.1.0
Usage: cql [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
...
```

## After
```
Claude Query Language (CQL) Compiler v0.1.0
Usage: cql [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
...
```

🤖 Generated with [Claude Code](https://claude.ai/code)