### PR TITLE
fix: Update PluggableLoggerTest to reflect NORMAL default log level

### DIFF
--- a/src/cql/test_pluggable_logger.cpp
+++ b/src/cql/test_pluggable_logger.cpp
@@ -148,11 +148,14 @@ TEST_F(PluggableLoggerTest, LoggerManager_DefaultInitialization) {
     // Auto-initialization should work
     EXPECT_FALSE(LoggerManager::is_initialized());
     
-    LoggerManager::log(LogLevel::INFO, "Test message");
+    LoggerManager::log(LogLevel::NORMAL, "Test message");
     EXPECT_TRUE(LoggerManager::is_initialized());
     
     // Should be able to check levels and flush
-    EXPECT_TRUE(LoggerManager::is_level_enabled(LogLevel::INFO));
+    // Default minimum level is NORMAL, so INFO should be disabled, NORMAL+ should be enabled
+    EXPECT_FALSE(LoggerManager::is_level_enabled(LogLevel::INFO));  // Below minimum
+    EXPECT_TRUE(LoggerManager::is_level_enabled(LogLevel::NORMAL));  // At minimum
+    EXPECT_TRUE(LoggerManager::is_level_enabled(LogLevel::ERROR));   // Above minimum
     EXPECT_NO_THROW(LoggerManager::flush());
 }
 


### PR DESCRIPTION
## Summary
Fixes failing `PluggableLoggerTest.LoggerManager_DefaultInitialization` test that was broken by recent logging improvements.

## 🐛 Problem
The test was expecting `LogLevel::INFO` to be enabled by default, but we recently changed the default minimum log level from `DEBUG` to `NORMAL` to reduce debug noise in CLI output.

**Test failure:**
```
Value of: LoggerManager::is_level_enabled(LogLevel::INFO)
  Actual: false
Expected: true
```

## ✅ Solution
Updated the test to reflect the correct new behavior:

### **Before:**
- Used `LogLevel::INFO` to trigger auto-initialization  
- Expected `INFO` level to be enabled
- Single level check

### **After:**  
- Uses `LogLevel::NORMAL` to trigger auto-initialization
- Comprehensive level checking that verifies the log level hierarchy:
  - `INFO (1)` → **disabled** (below NORMAL minimum)
  - `NORMAL (2)` → **enabled** (at minimum) 
  - `ERROR (3)` → **enabled** (above minimum)

## 🧪 Test Results
```bash
./cql_test --gtest_filter="PluggableLoggerTest.*"
[  PASSED  ] 15 tests.
```

All PluggableLoggerTest tests now pass, including the previously failing `LoggerManager_DefaultInitialization`.

## 🔗 Related Changes
This fix aligns with the recent logging improvements in PR #20 that:
- Changed default log level from DEBUG to NORMAL
- Removed debug logging from normal CLI operations  
- Maintained clean user experience while preserving debugging capabilities

The test now correctly validates the intended behavior of having NORMAL as the default minimum log level.

🤖 Generated with [Claude Code](https://claude.ai/code)