### PR TITLE
feat: Add --env flag for automatic .env file loading

### DIFF
--- a/include/cql/cql.hpp
+++ b/include/cql/cql.hpp
@@ -77,6 +77,10 @@ namespace util {
         const std::string& pattern,
         size_t group_index = 1
     );
+    
+    // load and parse a .env file, setting environment variables
+    // returns true if file was successfully loaded and parsed
+    bool load_env_file(const std::string& filepath = ".env");
 }
 
 /**

--- a/include/cql/cql.hpp
+++ b/include/cql/cql.hpp
@@ -80,6 +80,7 @@ namespace util {
     
     // load and parse a .env file, setting environment variables
     // returns true if file was successfully loaded and parsed
+    // throws SecurityValidationError for security issues
     bool load_env_file(const std::string& filepath = ".env");
 }
 

--- a/src/cql/application_controller.cpp
+++ b/src/cql/application_controller.cpp
@@ -97,6 +97,19 @@ int ApplicationController::run(int argc, char* argv[]) {
     // Check if headers should be included (default is clean output)
     bool include_headers = cmd_handler.has_option("--include-header");
     
+    // Check for --env flag to load .env file
+    std::string env_dummy;
+    if (cmd_handler.find_and_remove_option("--env", env_dummy)) {
+        if (util::load_env_file()) {
+            // Only log if headers are enabled to keep output clean
+            if (include_headers) {
+                std::cout << "Successfully loaded .env file" << std::endl;
+            }
+        } else {
+            std::cerr << "Warning: Could not load .env file" << std::endl;
+        }
+    }
+    
     if (include_headers) {
         std::cout << "Starting CQL Compiler v" << CQL_VERSION_STRING << " (" << CQL_BUILD_TIMESTAMP << ")..." << std::endl;
     }

--- a/src/cql/command_line_handler.cpp
+++ b/src/cql/command_line_handler.cpp
@@ -113,6 +113,7 @@ void CommandLineHandler::print_help() {
               << "  --version, -v           Show version information\n"
               << "  --interactive, -i       Run in interactive mode\n"
               << "  --clipboard, -c         Copy output to clipboard instead of writing to a file\n"
+              << "  --env                   Load environment variables from .env file\n"
               << "  --include-header        Include compiler headers and status messages in output\n"
               << "  --debug-level LEVEL     Set log level (INFO|NORMAL|DEBUG|ERROR|CRITICAL, default: DEBUG)\n"
               << "  --templates, -l         List all available templates\n"


### PR DESCRIPTION
## Summary
- Implement comprehensive .env file loading with `--env` flag
- Enable clean workflow for API operations without manual environment setup
- Add robust parsing for KEY=value format with quotes, comments, and error handling

## Changes Made
- **New utility function**: `cql::util::load_env_file()` with comprehensive .env parsing
- **Command-line integration**: Added `--env` flag processing in `ApplicationController`
- **Help documentation**: Updated help text with clear `--env` option description
- **Secure parsing**: Support for quoted values, comments, empty lines, and error handling

## Features
- **Clean workflow**: `./build/cql --env --optimize examples/api_basic_example.llm`
- **Optional behavior**: Doesn't interfere with existing workflows  
- **Standard pattern**: Follows common CLI tool conventions
- **User feedback**: Shows success/warning messages appropriately

## Testing
- ✅ Successfully loads .env file with CQL_API_KEY and ANTHROPIC_API_KEY
- ✅ Integrates cleanly with existing command-line processing
- ✅ Works with meta-prompt compilation and API operations
- ✅ Provides appropriate user feedback

## Usage Examples
```bash
# Before - Required manual setup:
export CQL_API_KEY="your-key" 
./build/cql --optimize examples/api_basic_example.llm

# After - Clean one-liner:
./build/cql --env --optimize examples/api_basic_example.llm --goal REDUCE_TOKENS
```

This addresses the exact problem we encountered during API testing and provides a much cleaner developer experience.

🤖 Generated with [Claude Code](https://claude.ai/code)