### PR TITLE
feat: Phase 4 - Clean up mixed output patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This document provides comprehensive context for AI assistants working on the CQ
 **Active Branch**: `feat/phase4-cleanup-mixed-output`
 **Current PR**: [#46 - Phase 4: Clean up mixed output patterns](https://github.com/dbjwhs/cql/pull/46)
 
-### Phase 4 PR Status: In Review 🔄
+### Phase 4 PR Status: Ready for Re-Review ✅
 
 **Completed Items:**
 - ✅ Updated cli.cpp to use UserOutputManager (~138 replacements)
@@ -16,9 +16,13 @@ This document provides comprehensive context for AI assistants working on the CQ
 - ✅ Updated documentation_handler.cpp to use UserOutputManager
 - ✅ Fixed test_meta_prompt_cli.cpp to use callback-based UserOutput
 - ✅ All 223 tests passing
+- ✅ **Review Feedback Addressed** (Commit 1115df0):
+  - Documented 6 interactive prompts that intentionally use `std::cout`
+  - Removed 9 unnecessary `std::to_string()` calls
+  - Verified newline handling consistency
 
 **What's Next:**
-- Awaiting review and approval for PR #46
+- Awaiting second review and approval for PR #46
 - Phase 3 or Phase 5 next (TBD based on priorities)
 
 ### Development Roadmap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,22 @@ This document provides comprehensive context for AI assistants working on the CQ
 
 ## Current Work Status
 
-**Active Branch**: `main` (No active feature branch)
-**Status**: Ready for Phase 3
+**Active Branch**: `feat/phase4-cleanup-mixed-output`
+**Current PR**: [#46 - Phase 4: Clean up mixed output patterns](https://github.com/dbjwhs/cql/pull/46)
+
+### Phase 4 PR Status: In Review 🔄
+
+**Completed Items:**
+- ✅ Updated cli.cpp to use UserOutputManager (~138 replacements)
+- ✅ Updated meta_prompt_handler.cpp to use UserOutputManager
+- ✅ Updated template_operations.cpp to use UserOutputManager
+- ✅ Updated documentation_handler.cpp to use UserOutputManager
+- ✅ Fixed test_meta_prompt_cli.cpp to use callback-based UserOutput
+- ✅ All 223 tests passing
+
+**What's Next:**
+- Awaiting review and approval for PR #46
+- Phase 3 or Phase 5 next (TBD based on priorities)
 
 ### Development Roadmap
 
@@ -13,7 +27,7 @@ This document provides comprehensive context for AI assistants working on the CQ
 - ✅ Phase 1: File-only logging by default with `--log-console` option (PR #44 - MERGED)
 - ✅ Phase 2: Separate user output from debug logging (PR #45 - MERGED)
 - 📋 Phase 3: Enhanced file logger configuration (rotation, timestamps)
-- 📋 Phase 4: Clean up mixed output patterns (update remaining files to use UserOutput)
+- 🔄 **Phase 4: Clean up mixed output patterns** (PR #46 - In Review)
 - 📋 Phase 5: Multi-logger with independent level control
 - 📋 Phase 6: Documentation and examples
 

--- a/src/cql/cli.cpp
+++ b/src/cql/cli.cpp
@@ -216,6 +216,8 @@ bool handle_template_basic_commands(const std::string& line,
                     UserOutputManager::info("  - ", issue.to_string());
                 }
 
+                // Note: Interactive prompts intentionally use std::cout (not UserOutputManager)
+                // to maintain synchronization with std::cin and ensure prompt appears before input
                 std::cout << "Do you want to save the template anyway? (y/n): ";
                 std::string response;
                 std::getline(std::cin, response);
@@ -411,6 +413,8 @@ bool handle_variable_commands(const std::string& line,
 
         while (true) {
             std::string var_line;
+            // Note: Interactive prompts intentionally use std::cout (not UserOutputManager)
+            // to maintain synchronization with std::cin and ensure prompt appears before input
             std::cout << "var> ";
             std::getline(std::cin, var_line);
 
@@ -455,6 +459,8 @@ bool handle_template_use(const std::string& line, std::string& current_query
                     UserOutputManager::info("  - ", issue.to_string());
                 }
 
+                // Note: Interactive prompts intentionally use std::cout (not UserOutputManager)
+                // to maintain synchronization with std::cin and ensure prompt appears before input
                 std::cout << "Do you want to use this template anyway? (y/n): ";
                 std::string response;
                 std::getline(std::cin, response);
@@ -513,6 +519,8 @@ bool handle_template_use(const std::string& line, std::string& current_query
                 Logger::getInstance().log(LogLevel::INFO, "Template is missing values for these variables:");
 
                 for (const auto& var : missing_vars) {
+                    // Note: Interactive prompts intentionally use std::cout (not UserOutputManager)
+                    // to maintain synchronization with std::cin and ensure prompt appears before input
                     std::cout << "  Enter value for '" << var << "': ";
                     std::string value;
                     std::getline(std::cin, value);
@@ -593,6 +601,8 @@ bool handle_template_inheritance(const std::string& line, std::string& current_q
                     UserOutputManager::info("  - ", issue.to_string());
                 }
 
+                // Note: Interactive prompts intentionally use std::cout (not UserOutputManager)
+                // to maintain synchronization with std::cin and ensure prompt appears before input
                 std::cout << "Do you want to save the template anyway? (y/n): ";
                 std::string response;
                 std::getline(std::cin, response);
@@ -632,7 +642,7 @@ bool handle_template_inheritance(const std::string& line, std::string& current_q
                     } else if (i == chain.size() - 1) {
                         UserOutputManager::info("  Current: ", chain[i]);
                     } else {
-                        UserOutputManager::info("  Parent ", std::to_string(i), ": ", chain[i]);
+                        UserOutputManager::info("  Parent ", i, ": ", chain[i]);
                     }
                 }
             }
@@ -657,9 +667,9 @@ bool handle_template_validation(const std::string& line, const TemplateManager& 
             UserOutputManager::info("------------------------------------------");
 
             if (result.has_issues()) {
-                UserOutputManager::info("Found ", std::to_string(result.count_errors()), " errors, ",
-                          std::to_string(result.count_warnings()), " warnings, ",
-                          std::to_string(result.count_infos()), " info messages.");
+                UserOutputManager::info("Found ", result.count_errors(), " errors, ",
+                          result.count_warnings(), " warnings, ",
+                          result.count_infos(), " info messages.");
 
                 // print errors
                 if (result.count_errors() > 0) {
@@ -697,7 +707,7 @@ bool handle_template_validation(const std::string& line, const TemplateManager& 
             if (const auto templates = template_manager.list_templates(); templates.empty()) {
                 Logger::getInstance().log(LogLevel::INFO, "No templates found to validate");
             } else {
-                UserOutputManager::info("Validating ", std::to_string(templates.size()), " templates...");
+                UserOutputManager::info("Validating ", templates.size(), " templates...");
                 UserOutputManager::info("----------------------------");
 
                 size_t error_count = 0;
@@ -719,11 +729,11 @@ bool handle_template_validation(const std::string& line, const TemplateManager& 
                     // print progress
                     if (result.has_issues(TemplateValidationLevel::ERROR)) {
                         templates_with_errors.push_back(tmpl);
-                        UserOutputManager::info("❌ ", tmpl, ": ", std::to_string(result.count_errors()), " errors, ",
-                                  std::to_string(result.count_warnings()), " warnings");
+                        UserOutputManager::info("❌ ", tmpl, ": ", result.count_errors(), " errors, ",
+                                  result.count_warnings(), " warnings");
                     } else if (result.has_issues(TemplateValidationLevel::WARNING)) {
                         templates_with_warnings.push_back(tmpl);
-                        UserOutputManager::info("⚠️ ", tmpl, ": ", std::to_string(result.count_warnings()), " warnings");
+                        UserOutputManager::info("⚠️ ", tmpl, ": ", result.count_warnings(), " warnings");
                     } else {
                         UserOutputManager::info("✅ ", tmpl, ": No issues");
                     }
@@ -732,11 +742,11 @@ bool handle_template_validation(const std::string& line, const TemplateManager& 
                 // print summary
                 UserOutputManager::info("\nValidation Summary:");
                 UserOutputManager::info("----------------------------");
-                UserOutputManager::info("Templates validated: ", std::to_string(templates.size()));
-                UserOutputManager::info("Total issues: ", std::to_string(error_count + warning_count + info_count), " (",
-                          std::to_string(error_count), " errors, ",
-                          std::to_string(warning_count), " warnings, ",
-                          std::to_string(info_count), " info messages)");
+                UserOutputManager::info("Templates validated: ", templates.size());
+                UserOutputManager::info("Total issues: ", error_count + warning_count + info_count, " (",
+                          error_count, " errors, ",
+                          warning_count, " warnings, ",
+                          info_count, " info messages)");
 
                 // list templates with errors
                 if (!templates_with_errors.empty()) {
@@ -1097,6 +1107,8 @@ void run_interactive() {
      */
     while (true) {
         // Prompt and read user input
+        // Note: Interactive prompts intentionally use std::cout (not UserOutputManager)
+        // to maintain synchronization with std::cin and ensure prompt appears before input
         std::cout << "> ";
         std::getline(std::cin, line);
 
@@ -1217,7 +1229,7 @@ std::vector<GeneratedFile> process_api_response(const ApiResponse& response, Api
     std::vector<GeneratedFile> files = processor.process_response(response.m_raw_response);
 
     Logger::getInstance().log(LogLevel::INFO, "Generated ", files.size(), " files:");
-    UserOutputManager::info("Generated ", std::to_string(files.size()), " files:");
+    UserOutputManager::info("Generated ", files.size(), " files:");
 
     for (const auto& file : files) {
         Logger::getInstance().log(LogLevel::INFO, "- ", file.m_filename);

--- a/src/cql/cli.cpp
+++ b/src/cql/cli.cpp
@@ -13,6 +13,7 @@
 #include "../../include/cql/api_client.hpp"
 #include "../../include/cql/response_processor.hpp"
 #include "../../include/cql/project_utils.hpp"
+#include "../../include/cql/user_output_manager.hpp"
 
 namespace cql::cli {
 
@@ -27,43 +28,44 @@ TemplateValidator initialize_template_validator(const TemplateManager& template_
          const auto &rule: schema.get_validation_rules() | std::views::values) {
         template_validator.add_validation_rule(rule);
     }
-    
+
     return template_validator;
 }
 
 // Display help menu
 void display_help_menu() {
-    std::cout << "Commands:\n"
-              << "  help                    - Show this help\n"
-              << "  exit/quit               - Exit the program\n"
-              << "  clear                   - Clear the current query\n"
-              << "  show                    - Show the current query\n"
-              << "  compile                 - Compile the current query\n"
-              << "  load FILE               - Load query from file\n"
-              << "  save FILE               - Save compiled query to file\n"
-              << "\n"
-              << "Template Commands:\n"
-              << "  templates               - List all available templates\n"
-              << "  template save NAME      - Save current query as a template\n"
-              << "  template load NAME      - Load a template\n"
-              << "  template info NAME      - Show info about a template\n"
-              << "  template delete NAME    - Delete a template\n"
-              << "  template vars NAME      - List variables in a template\n"
-              << "  template setvar NAME=VAL - Set a template variable\n"
-              << "  template setvars        - Enter multiple variables interactively\n"
-              << "  template vars           - Show current variables in memory\n"
-              << "  template clearvars      - Clear all current variables\n"
-              << "  template use NAME       - Use a template with current variables\n"
-              << "  template dir [PATH]     - Show or set templates directory\n"
-              << "  template inherit CHILD PARENT - Create a template inheriting from another\n"
-              << "  template parents NAME   - Show inheritance chain for a template\n"
-              << "  template validate NAME  - Validate a template\n"
-              << "  template validateall    - Validate all templates\n"
-              << "  template docs NAME      - Generate documentation for a template\n"
-              << "  template docsall        - Generate documentation for all templates\n"
-              << "  template export PATH [format] - Export documentation to a file (formats: md, html, txt)\n"
-              << "  categories              - List template categories\n"
-              << "  category create NAME    - Create a new template category\n";
+    UserOutputManager::info(
+        "Commands:\n"
+        "  help                    - Show this help\n"
+        "  exit/quit               - Exit the program\n"
+        "  clear                   - Clear the current query\n"
+        "  show                    - Show the current query\n"
+        "  compile                 - Compile the current query\n"
+        "  load FILE               - Load query from file\n"
+        "  save FILE               - Save compiled query to file\n"
+        "\n"
+        "Template Commands:\n"
+        "  templates               - List all available templates\n"
+        "  template save NAME      - Save current query as a template\n"
+        "  template load NAME      - Load a template\n"
+        "  template info NAME      - Show info about a template\n"
+        "  template delete NAME    - Delete a template\n"
+        "  template vars NAME      - List variables in a template\n"
+        "  template setvar NAME=VAL - Set a template variable\n"
+        "  template setvars        - Enter multiple variables interactively\n"
+        "  template vars           - Show current variables in memory\n"
+        "  template clearvars      - Clear all current variables\n"
+        "  template use NAME       - Use a template with current variables\n"
+        "  template dir [PATH]     - Show or set templates directory\n"
+        "  template inherit CHILD PARENT - Create a template inheriting from another\n"
+        "  template parents NAME   - Show inheritance chain for a template\n"
+        "  template validate NAME  - Validate a template\n"
+        "  template validateall    - Validate all templates\n"
+        "  template docs NAME      - Generate documentation for a template\n"
+        "  template docsall        - Generate documentation for all templates\n"
+        "  template export PATH [format] - Export documentation to a file (formats: md, html, txt)\n"
+        "  categories              - List template categories\n"
+        "  category create NAME    - Create a new template category\n");
 }
 
 // Handle basic query commands (clear, show, compile, load, save)
@@ -89,7 +91,7 @@ bool handle_basic_commands(const std::string& line, std::string& current_query) 
 
         try {
             const std::string result = QueryProcessor::compile(current_query);
-            Logger::getInstance().log(LogLevel::INFO, "\n=== Compiled Query ===\n\n", 
+            Logger::getInstance().log(LogLevel::INFO, "\n=== Compiled Query ===\n\n",
                                      result, "\n===================");
         } catch (const std::exception& e) {
             Logger::getInstance().log(LogLevel::ERROR, "Compilation error: ", e.what());
@@ -133,7 +135,7 @@ bool handle_list_commands(const std::string& line, const TemplateManager& templa
             } else {
                 Logger::getInstance().log(LogLevel::INFO, "Available templates:");
                 for (const auto& tmpl : templates) {
-                    std::cout << "  " << tmpl << std::endl;
+                    UserOutputManager::info("  ", tmpl);
                 }
             }
         } catch (const std::exception& e) {
@@ -148,7 +150,7 @@ bool handle_list_commands(const std::string& line, const TemplateManager& templa
             } else {
                 Logger::getInstance().log(LogLevel::INFO, "Available categories:");
                 for (const auto& category : categories) {
-                    std::cout << "  " << category << std::endl;
+                    UserOutputManager::info("  ", category);
                 }
             }
         } catch (const std::exception& e) {
@@ -175,8 +177,7 @@ bool handle_list_commands(const std::string& line, const TemplateManager& templa
 // Template directory commands
 bool handle_template_dir_commands(const std::string& line, TemplateManager& template_manager) {
     if (line == "template dir") {
-        std::cout << "Templates directory: " 
-                 << template_manager.get_templates_directory() << std::endl;
+        UserOutputManager::info("Templates directory: ", template_manager.get_templates_directory());
         return true;
     }
     if (line.substr(0, 13) == "template dir ") {
@@ -193,7 +194,7 @@ bool handle_template_dir_commands(const std::string& line, TemplateManager& temp
 }
 
 // Handle template save/load/delete/info commands
-bool handle_template_basic_commands(const std::string& line, 
+bool handle_template_basic_commands(const std::string& line,
                                    std::string& current_query,
                                    TemplateManager& template_manager,
                                    TemplateValidator& template_validator) {
@@ -212,13 +213,13 @@ bool handle_template_basic_commands(const std::string& line,
                 validation_result.has_issues(TemplateValidationLevel::ERROR)) {
                 Logger::getInstance().log(LogLevel::ERROR, "Template validation failed with errors:");
                 for (const auto& issue : validation_result.get_issues(TemplateValidationLevel::ERROR)) {
-                    std::cout << "  - " << issue.to_string() << std::endl;
+                    UserOutputManager::info("  - ", issue.to_string());
                 }
-                
+
                 std::cout << "Do you want to save the template anyway? (y/n): ";
                 std::string response;
                 std::getline(std::cin, response);
-                
+
                 if (response != "y" && response != "Y") {
                     Logger::getInstance().log(LogLevel::INFO, "Template save cancelled");
                     return true;
@@ -226,7 +227,7 @@ bool handle_template_basic_commands(const std::string& line,
             } else if (validation_result.has_issues(TemplateValidationLevel::WARNING)) {
                 Logger::getInstance().log(LogLevel::NORMAL, "Template has validation warnings:");
                 for (const auto& issue : validation_result.get_issues(TemplateValidationLevel::WARNING)) {
-                    std::cout << "  - " << issue.to_string() << std::endl;
+                    UserOutputManager::info("  - ", issue.to_string());
                 }
             }
 
@@ -252,22 +253,22 @@ bool handle_template_basic_commands(const std::string& line,
         try {
             auto [template_name, template_description, template_variables, template_last_modified, template_parent]
                 = template_manager.get_template_metadata(name);
-            std::cout << "Template: " << template_name << std::endl;
-            std::cout << "Description: " << template_description << std::endl;
-            std::cout << "Last modified: " << template_last_modified << std::endl;
+            UserOutputManager::info("Template: ", template_name);
+            UserOutputManager::info("Description: ", template_description);
+            UserOutputManager::info("Last modified: ", template_last_modified);
 
             // show the parent template if it exists
             if (template_parent.has_value() && !template_parent.value().empty()) {
-                std::cout << "Inherits from: " << template_parent.value() << std::endl;
+                UserOutputManager::info("Inherits from: ", template_parent.value());
             }
 
             if (!template_variables.empty()) {
-                std::cout << "Variables:" << std::endl;
+                UserOutputManager::info("Variables:");
                 for (const auto& var : template_variables) {
-                    std::cout << "  ${" << var << "}" << std::endl;
+                    UserOutputManager::info("  ${", var, "}");
                 }
             } else {
-                std::cout << "No variables found" << std::endl;
+                UserOutputManager::info("No variables found");
             }
         } catch (const std::exception& e) {
             Logger::getInstance().log(LogLevel::ERROR, "Failed to get template info: ", e.what());
@@ -287,35 +288,35 @@ bool handle_template_basic_commands(const std::string& line,
         }
         return true;
     }
-    
+
     return false;
 }
 
 // Handle variable management commands
-bool handle_variable_commands(const std::string& line, 
+bool handle_variable_commands(const std::string& line,
                              std::string& current_query,
                              std::map<std::string, std::string>& current_variables,
                              TemplateManager& template_manager) {
     if (line.substr(0, 16) == "template setvar ") {
         std::string var_def = line.substr(16);
         size_t equals_pos = var_def.find('=');
-        
+
         if (equals_pos == std::string::npos) {
             Logger::getInstance().log(LogLevel::ERROR, "Invalid variable format. Use NAME=VALUE");
             return true;
         }
-        
+
         std::string name = var_def.substr(0, equals_pos);
         std::string value = var_def.substr(equals_pos + 1);
-        
+
         // add/update the variable in both current query- and memory -
         // first update in memory for future template usage
         current_variables[name] = value;
-        
+
         // then update in the current query if it exists
         std::stringstream new_query;
         bool variable_updated = false;
-        
+
         // if the query is empty, add the variable
         if (current_query.empty()) {
             new_query << "@variable \"" << name << "\" \"" << value << "\"";
@@ -337,7 +338,7 @@ bool handle_variable_commands(const std::string& line,
                 }
                 new_query << std::endl;
             }
-            
+
             // if the variable wasn't found, add it at the beginning
             if (!variable_updated) {
                 std::string var_declaration = "@variable \"";
@@ -351,7 +352,7 @@ bool handle_variable_commands(const std::string& line,
                 current_query = new_query.str();
             }
         }
-        
+
         if (variable_updated) {
             Logger::getInstance().log(LogLevel::INFO, "Variable updated: ", name, "=", value);
         } else {
@@ -366,7 +367,7 @@ bool handle_variable_commands(const std::string& line,
         } else {
             Logger::getInstance().log(LogLevel::INFO, "Current variables:");
             for (const auto& [name, value] : current_variables) {
-                std::cout << "  " << name << " = \"" << value << "\"" << std::endl;
+                UserOutputManager::info("  ", name, " = \"", value, "\"");
             }
         }
         return true;
@@ -385,18 +386,18 @@ bool handle_variable_commands(const std::string& line,
                 Logger::getInstance().log(LogLevel::INFO, "No variables found in template: ", template_name);
             } else {
                 Logger::getInstance().log(LogLevel::INFO, "Variables in template: ", template_name);
-                
+
                 // get template content to extract default values if available
                 std::string content = template_manager.load_template(template_name);
                 auto variables_with_values = cql::TemplateManager::collect_variables(content);
-                
+
                 for (const auto& var_name : metadata.variables) {
                     std::string default_value;
                     if (variables_with_values.contains(var_name))
                         default_value = variables_with_values[var_name];
                     else
                         default_value = "(no default)";
-                    std::cout << "  " << var_name << " = \"" << default_value << "\"" << std::endl;
+                    UserOutputManager::info("  ", var_name, " = \"", default_value, "\"");
                 }
             }
         } catch (const std::exception& e) {
@@ -407,30 +408,30 @@ bool handle_variable_commands(const std::string& line,
     if (line == "template setvars") {
         // interactive mode for setting multiple variables
         Logger::getInstance().log(LogLevel::INFO, "Enter variables in NAME=VALUE format (empty line to finish):");
-        
+
         while (true) {
             std::string var_line;
             std::cout << "var> ";
             std::getline(std::cin, var_line);
-            
+
             if (var_line.empty()) {
                 break;
             }
-            
+
             size_t equals_pos = var_line.find('=');
             if (equals_pos == std::string::npos) {
                 Logger::getInstance().log(LogLevel::ERROR, "Invalid format. Use NAME=VALUE");
                 continue;
             }
-            
+
             std::string name = var_line.substr(0, equals_pos);
             std::string value = var_line.substr(equals_pos + 1);
-            
+
             // add to current variables
             current_variables[name] = value;
             Logger::getInstance().log(LogLevel::INFO, "Variable set: ", name, "=", value);
         }
-        
+
         Logger::getInstance().log(LogLevel::INFO, "Finished setting variables");
         return true;
     }
@@ -446,18 +447,18 @@ bool handle_template_use(const std::string& line, std::string& current_query
         try {
             // first validate the template
             auto validation_result = template_validator.validate_template(name);
-            
+
             // check for critical errors
             if (validation_result.has_issues(TemplateValidationLevel::ERROR)) {
                 Logger::getInstance().log(LogLevel::ERROR, "Template validation failed with errors:");
                 for (const auto& issue : validation_result.get_issues(TemplateValidationLevel::ERROR)) {
-                    std::cout << "  - " << issue.to_string() << std::endl;
+                    UserOutputManager::info("  - ", issue.to_string());
                 }
-                
+
                 std::cout << "Do you want to use this template anyway? (y/n): ";
                 std::string response;
                 std::getline(std::cin, response);
-                
+
                 if (response != "y" && response != "Y") {
                     Logger::getInstance().log(LogLevel::INFO, "Template use cancelled");
                     return true;
@@ -465,7 +466,7 @@ bool handle_template_use(const std::string& line, std::string& current_query
             } else if (validation_result.has_issues(TemplateValidationLevel::WARNING)) {
                 Logger::getInstance().log(LogLevel::NORMAL, "Template has validation warnings:");
                 for (const auto& issue : validation_result.get_issues(TemplateValidationLevel::WARNING)) {
-                    std::cout << "  - " << issue.to_string() << std::endl;
+                    UserOutputManager::info("  - ", issue.to_string());
                 }
             }
 
@@ -474,28 +475,28 @@ bool handle_template_use(const std::string& line, std::string& current_query
             std::istringstream iss(current_query);
             std::string curr_line;
             std::regex var_regex("@variable\\s+\"([^\"]*)\"\\s+\"([^\"]*)\"");
-            
+
             while (std::getline(iss, curr_line)) {
                 if (std::smatch match; std::regex_match(curr_line, match, var_regex) && match.size() > 2) {
                     variables[match[1].str()] = match[2].str();
                 }
             }
-            
+
             // combine current variables with template variables will override memory variables
             // if there are duplicates
             std::map<std::string, std::string> combined_variables = current_variables;
             for (const auto& [name, value] : variables) {
                 combined_variables[name] = value;
             }
-            
+
             // check for missing variables
             std::string template_content = template_manager.load_template(name);
             auto template_vars = cql::TemplateManager::collect_variables(template_content);
-            
+
             // get all variables used in the template from a validation result
             auto referenced_vars = validation_result.get_issues(TemplateValidationLevel::INFO);
             std::vector<std::string> missing_vars;
-            
+
             // check for variables that are referenced but not declared
             for (const auto& issue : referenced_vars) {
                 // if the issue is about a variable, check if it's available
@@ -506,11 +507,11 @@ bool handle_template_use(const std::string& line, std::string& current_query
                     }
                 }
             }
-            
+
             // if there are missing variables, prompt the user to enter them
             if (!missing_vars.empty()) {
                 Logger::getInstance().log(LogLevel::INFO, "Template is missing values for these variables:");
-                
+
                 for (const auto& var : missing_vars) {
                     std::cout << "  Enter value for '" << var << "': ";
                     std::string value;
@@ -518,7 +519,7 @@ bool handle_template_use(const std::string& line, std::string& current_query
                     combined_variables[var] = value;
                 }
             }
-            
+
             // instantiate the template with the variables
             current_query = template_manager.instantiate_template(name, combined_variables);
             Logger::getInstance().log(LogLevel::INFO, "Template instantiated: ", name);
@@ -537,20 +538,20 @@ bool handle_template_inheritance(const std::string& line, std::string& current_q
         std::string params = line.substr(17);
         size_t space_pos = params.find(' ');
         if (space_pos == std::string::npos) {
-            Logger::getInstance().log(LogLevel::ERROR, 
+            Logger::getInstance().log(LogLevel::ERROR,
                 "Invalid format. Use: template inherit CHILD_NAME PARENT_NAME");
             return true;
         }
-        
+
         std::string child_name = params.substr(0, space_pos);
         std::string parent_name = params.substr(space_pos + 1);
-        
+
         try {
             if (current_query.empty()) {
                 Logger::getInstance().log(LogLevel::ERROR, "Cannot create inherited template with empty content");
                 return true;
             }
-            
+
             // add inherit directive if not already present
             if (std::regex inherit_regex("@inherit\\s+\"([^\"]*)\""); !std::regex_search(current_query, inherit_regex)) {
                 // add @inherit directive at the beginning of the content
@@ -559,10 +560,10 @@ bool handle_template_inheritance(const std::string& line, std::string& current_q
                 current_query.append("\"\n");
                 current_query.append(saved_query);
             }
-            
+
             // validate the template before saving
             auto validation_result = template_validator.validate_content(current_query);
-            
+
             // check for inheritance errors
             bool has_inheritance_error = false;
             for (const auto& issue : validation_result.get_issues(TemplateValidationLevel::ERROR)) {
@@ -572,30 +573,30 @@ bool handle_template_inheritance(const std::string& line, std::string& current_q
                     break;
                 }
             }
-            
+
             // if there are inheritance errors, don't allow override
             if (has_inheritance_error) {
                 Logger::getInstance().log(LogLevel::ERROR, "Template inheritance validation failed:");
                 for (const auto& issue : validation_result.get_issues(TemplateValidationLevel::ERROR)) {
-                    if (issue.to_string().find("inherit") != std::string::npos || 
+                    if (issue.to_string().find("inherit") != std::string::npos ||
                         issue.to_string().find("circular") != std::string::npos) {
-                        std::cout << "  - " << issue.to_string() << std::endl;
+                        UserOutputManager::info("  - ", issue.to_string());
                     }
                 }
                 return true;
             }
-            
+
             // for other validation errors, prompt for confirmation
             if (validation_result.has_issues(TemplateValidationLevel::ERROR)) {
                 Logger::getInstance().log(LogLevel::ERROR, "Template validation failed with errors:");
                 for (const auto& issue : validation_result.get_issues(TemplateValidationLevel::ERROR)) {
-                    std::cout << "  - " << issue.to_string() << std::endl;
+                    UserOutputManager::info("  - ", issue.to_string());
                 }
-                
+
                 std::cout << "Do you want to save the template anyway? (y/n): ";
                 std::string response;
                 std::getline(std::cin, response);
-                
+
                 if (response != "y" && response != "Y") {
                     Logger::getInstance().log(LogLevel::INFO, "Template save cancelled");
                     return true;
@@ -603,12 +604,12 @@ bool handle_template_inheritance(const std::string& line, std::string& current_q
             } else if (validation_result.has_issues(TemplateValidationLevel::WARNING)) {
                 Logger::getInstance().log(LogLevel::NORMAL, "Template has validation warnings:");
                 for (const auto& issue : validation_result.get_issues(TemplateValidationLevel::WARNING)) {
-                    std::cout << "  - " << issue.to_string() << std::endl;
+                    UserOutputManager::info("  - ", issue.to_string());
                 }
             }
-            
+
             template_manager.create_inherited_template(child_name, parent_name, current_query);
-            Logger::getInstance().log(LogLevel::INFO, "Created template '", child_name, 
+            Logger::getInstance().log(LogLevel::INFO, "Created template '", child_name,
                                      "' inheriting from '", parent_name, "'");
         } catch (const std::exception& e) {
             Logger::getInstance().log(LogLevel::ERROR, "Failed to create inherited template: ", e.what());
@@ -619,19 +620,19 @@ bool handle_template_inheritance(const std::string& line, std::string& current_q
         std::string template_name = line.substr(17);
         try {
             if (auto chain = template_manager.get_inheritance_chain(template_name); chain.size() <= 1) {
-                Logger::getInstance().log(LogLevel::INFO, "Template '", template_name, 
+                Logger::getInstance().log(LogLevel::INFO, "Template '", template_name,
                                          "' does not inherit from any other template");
             } else {
                 Logger::getInstance().log(LogLevel::INFO, "Inheritance chain for '", template_name, "':");
-                
+
                 for (size_t i = 0; i < chain.size(); ++i) {
                     // the first template is the base, the last is the current template
                     if (i == 0) {
-                        std::cout << "  Base: " << chain[i] << std::endl;
+                        UserOutputManager::info("  Base: ", chain[i]);
                     } else if (i == chain.size() - 1) {
-                        std::cout << "  Current: " << chain[i] << std::endl;
+                        UserOutputManager::info("  Current: ", chain[i]);
                     } else {
-                        std::cout << "  Parent " << i << ": " << chain[i] << std::endl;
+                        UserOutputManager::info("  Parent ", std::to_string(i), ": ", chain[i]);
                     }
                 }
             }
@@ -650,37 +651,37 @@ bool handle_template_validation(const std::string& line, const TemplateManager& 
         const std::string template_name = line.substr(18);
         try {
             const auto result = template_validator.validate_template(template_name);
-            
+
             // output validation results
-            std::cout << "Validation results for template '" << template_name << "':" << std::endl;
-            std::cout << "------------------------------------------" << std::endl;
-            
+            UserOutputManager::info("Validation results for template '", template_name, "':");
+            UserOutputManager::info("------------------------------------------");
+
             if (result.has_issues()) {
-                std::cout << "Found " << result.count_errors() << " errors, "
-                          << result.count_warnings() << " warnings, "
-                          << result.count_infos() << " info messages." << std::endl;
-                
+                UserOutputManager::info("Found ", std::to_string(result.count_errors()), " errors, ",
+                          std::to_string(result.count_warnings()), " warnings, ",
+                          std::to_string(result.count_infos()), " info messages.");
+
                 // print errors
                 if (result.count_errors() > 0) {
-                    std::cout << "\nErrors:" << std::endl;
+                    UserOutputManager::info("\nErrors:");
                     for (const auto& issue : result.get_issues(TemplateValidationLevel::ERROR)) {
-                        std::cout << "  - " << issue.to_string() << std::endl;
+                        UserOutputManager::info("  - ", issue.to_string());
                     }
                 }
-                
+
                 // print warnings
                 if (result.count_warnings() > 0) {
-                    std::cout << "\nWarnings:" << std::endl;
+                    UserOutputManager::info("\nWarnings:");
                     for (const auto& issue : result.get_issues(TemplateValidationLevel::WARNING)) {
-                        std::cout << "  - " << issue.to_string() << std::endl;
+                        UserOutputManager::info("  - ", issue.to_string());
                     }
                 }
-                
+
                 // print info messages
                 if (result.count_infos() > 0) {
-                    std::cout << "\nInfo:" << std::endl;
+                    UserOutputManager::info("\nInfo:");
                     for (const auto& issue : result.get_issues(TemplateValidationLevel::INFO)) {
-                        std::cout << "  - " << issue.to_string() << std::endl;
+                        UserOutputManager::info("  - ", issue.to_string());
                     }
                 }
             } else {
@@ -696,61 +697,61 @@ bool handle_template_validation(const std::string& line, const TemplateManager& 
             if (const auto templates = template_manager.list_templates(); templates.empty()) {
                 Logger::getInstance().log(LogLevel::INFO, "No templates found to validate");
             } else {
-                std::cout << "Validating " << templates.size() << " templates..." << std::endl;
-                std::cout << "----------------------------" << std::endl;
-                
+                UserOutputManager::info("Validating ", std::to_string(templates.size()), " templates...");
+                UserOutputManager::info("----------------------------");
+
                 size_t error_count = 0;
                 size_t warning_count = 0;
                 size_t info_count = 0;
-                
+
                 // keep track of templates with issues
                 std::vector<std::string> templates_with_errors;
                 std::vector<std::string> templates_with_warnings;
-                
+
                 for (const auto& tmpl : templates) {
                     auto result = template_validator.validate_template(tmpl);
-                    
+
                     // count issues
                     error_count += result.count_errors();
                     warning_count += result.count_warnings();
                     info_count += result.count_infos();
-                    
+
                     // print progress
                     if (result.has_issues(TemplateValidationLevel::ERROR)) {
                         templates_with_errors.push_back(tmpl);
-                        std::cout << "❌ " << tmpl << ": " << result.count_errors() << " errors, "
-                                  << result.count_warnings() << " warnings" << std::endl;
+                        UserOutputManager::info("❌ ", tmpl, ": ", std::to_string(result.count_errors()), " errors, ",
+                                  std::to_string(result.count_warnings()), " warnings");
                     } else if (result.has_issues(TemplateValidationLevel::WARNING)) {
                         templates_with_warnings.push_back(tmpl);
-                        std::cout << "⚠️ " << tmpl << ": " << result.count_warnings() << " warnings" << std::endl;
+                        UserOutputManager::info("⚠️ ", tmpl, ": ", std::to_string(result.count_warnings()), " warnings");
                     } else {
-                        std::cout << "✅ " << tmpl << ": No issues" << std::endl;
+                        UserOutputManager::info("✅ ", tmpl, ": No issues");
                     }
                 }
-                
+
                 // print summary
-                std::cout << "\nValidation Summary:" << std::endl;
-                std::cout << "----------------------------" << std::endl;
-                std::cout << "Templates validated: " << templates.size() << std::endl;
-                std::cout << "Total issues: " << (error_count + warning_count + info_count) << " ("
-                          << error_count << " errors, " 
-                          << warning_count << " warnings, " 
-                          << info_count << " info messages)" << std::endl;
-                
+                UserOutputManager::info("\nValidation Summary:");
+                UserOutputManager::info("----------------------------");
+                UserOutputManager::info("Templates validated: ", std::to_string(templates.size()));
+                UserOutputManager::info("Total issues: ", std::to_string(error_count + warning_count + info_count), " (",
+                          std::to_string(error_count), " errors, ",
+                          std::to_string(warning_count), " warnings, ",
+                          std::to_string(info_count), " info messages)");
+
                 // list templates with errors
                 if (!templates_with_errors.empty()) {
-                    std::cout << "\nTemplates with errors:" << std::endl;
+                    UserOutputManager::info("\nTemplates with errors:");
                     for (const auto& tmpl : templates_with_errors) {
-                        std::cout << "  - " << tmpl << std::endl;
+                        UserOutputManager::info("  - ", tmpl);
                     }
-                    std::cout << "Run 'template validate <n>' for details" << std::endl;
+                    UserOutputManager::info("Run 'template validate <n>' for details");
                 }
-                
+
                 if (error_count > 0) {
-                    Logger::getInstance().log(LogLevel::ERROR, 
+                    Logger::getInstance().log(LogLevel::ERROR,
                         "Validation found ", error_count, " errors in ", templates_with_errors.size(), " template(s)");
                 } else if (warning_count > 0) {
-                    Logger::getInstance().log(LogLevel::NORMAL, 
+                    Logger::getInstance().log(LogLevel::NORMAL,
                         "Validation found ", warning_count, " warnings in ", templates_with_warnings.size(), " template(s)");
                 } else {
                     Logger::getInstance().log(LogLevel::INFO, "All templates validated successfully");
@@ -770,11 +771,11 @@ bool handle_template_documentation(const std::string& line, const TemplateManage
         const std::string template_name = line.substr(14);
         try {
             std::string docs = template_manager.generate_template_documentation(template_name);
-            
-            std::cout << "\n===== Template Documentation =====\n\n";
-            std::cout << docs << std::endl;
-            std::cout << "\n==================================" << std::endl;
-            
+
+            UserOutputManager::info("\n===== Template Documentation =====\n");
+            UserOutputManager::info(docs);
+            UserOutputManager::info("\n==================================");
+
             Logger::getInstance().log(LogLevel::INFO, "generated documentation for template: ", template_name);
         } catch (const std::exception& e) {
             Logger::getInstance().log(LogLevel::ERROR, "error generating template documentation: ", e.what());
@@ -784,13 +785,13 @@ bool handle_template_documentation(const std::string& line, const TemplateManage
     if (line == "template docsall") {
         try {
             std::string docs = template_manager.generate_all_template_documentation();
-            
-            std::cout << "\n===== Template Documentation =====\n\n";
-            std::cout << "this is a preview of the documentation. use 'template export' to save to a file." << std::endl;
-            std::cout << "\n" << docs.substr(0, 1000) << "..." << std::endl;
-            std::cout << "\n(documentation truncated for display. use 'template export' to view full documentation)" << std::endl;
-            std::cout << "\n==================================" << std::endl;
-            
+
+            UserOutputManager::info("\n===== Template Documentation =====\n");
+            UserOutputManager::info("this is a preview of the documentation. use 'template export' to save to a file.");
+            UserOutputManager::info("\n", docs.substr(0, 1000), "...");
+            UserOutputManager::info("\n(documentation truncated for display. use 'template export' to view full documentation)");
+            UserOutputManager::info("\n==================================");
+
             Logger::getInstance().log(LogLevel::INFO, "generated documentation for all templates");
         } catch (const std::exception& e) {
             Logger::getInstance().log(LogLevel::ERROR, "error generating template documentation: ", e.what());
@@ -801,7 +802,7 @@ bool handle_template_documentation(const std::string& line, const TemplateManage
         std::string params = line.substr(16);
         std::string output_path;
         std::string format = "markdown"; // default format
-        
+
         // check if a format is specified
         size_t space_pos = params.find(' ');
         if (space_pos != std::string::npos) {
@@ -810,11 +811,11 @@ bool handle_template_documentation(const std::string& line, const TemplateManage
         } else {
             output_path = params;
         }
-        
+
         try {
             // export the documentation
             if (template_manager.export_documentation(output_path, format)) {
-                Logger::getInstance().log(LogLevel::INFO, 
+                Logger::getInstance().log(LogLevel::INFO,
                     "template documentation exported to ", output_path, " in ", format, " format");
             } else {
                 Logger::getInstance().log(LogLevel::ERROR, "failed to export template documentation");
@@ -861,7 +862,7 @@ bool exact_match(const std::string& input, const std::string& command) {
 
 /**
  * @brief Command matcher for prefix string matches
- * 
+ *
  * Used for commands with arguments (e.g., "load filename.txt")
  *
  * @param input User input to check
@@ -885,13 +886,13 @@ void run_interactive() {
     std::string line;                // Current input line
     std::string current_query;       // Query being constructed
     TemplateManager template_manager;// Template manager instance
-    
+
     // Create template validator with default schema
     TemplateValidator template_validator = initialize_template_validator(template_manager);
-    
+
     // Store variables in memory for template instantiation
     std::map<std::string, std::string> current_variables;
-    
+
     // Create interactive context for command handlers
     InteractiveContext context = {
         current_query,              // Shared query content
@@ -899,19 +900,19 @@ void run_interactive() {
         template_validator,         // Shared validator
         current_variables           // Shared variables
     };
-    
+
     /**
      * @brief Registry of command matchers and handlers
-     * 
+     *
      * Each entry is a pair containing:
      * 1. A matcher function that determines if input matches a command
      * 2. A handler function that implements the command's behavior
      */
     std::vector<std::pair<std::function<bool(const std::string&)>, CommandHandler>> commands;
-    
+
     /**
      * @brief Help command definition
-     * 
+     *
      * Displays the list of available commands.
      */
     commands.emplace_back(
@@ -924,15 +925,15 @@ void run_interactive() {
             return true;
         }
     );
-    
+
     /**
      * @brief Basic query management commands
-     * 
+     *
      * Includes: clear, show, compile, load, save
      */
     commands.emplace_back(
         // Matcher for basic query commands
-        [](const std::string& input) { 
+        [](const std::string& input) {
             return exact_match(input, "clear")   ||
                    exact_match(input, "show")    ||
                    exact_match(input, "compile") ||
@@ -944,16 +945,16 @@ void run_interactive() {
             return handle_basic_commands(input, ctx.current_query);
         }
     );
-    
+
     /**
      * @brief Template listing and category commands
-     * 
+     *
      * Includes: templates, categories, category create
      */
     commands.emplace_back(
         // Matcher for listing commands
-        [](const std::string& input) { 
-            return exact_match(input, "templates") || 
+        [](const std::string& input) {
+            return exact_match(input, "templates") ||
                    exact_match(input, "categories") ||
                    prefix_match(input, "category create ");
         },
@@ -962,16 +963,16 @@ void run_interactive() {
             return handle_list_commands(input, ctx.template_manager);
         }
     );
-    
+
     /**
      * @brief Template directory management commands
-     * 
+     *
      * Includes: template dir, template dir [path]
      */
     commands.emplace_back(
         // Matcher for template directory commands
-        [](const std::string& input) { 
-            return exact_match(input, "template dir") || 
+        [](const std::string& input) {
+            return exact_match(input, "template dir") ||
                    prefix_match(input, "template dir ");
         },
         // Handler delegates to template_dir_commands implementation
@@ -979,16 +980,16 @@ void run_interactive() {
             return handle_template_dir_commands(input, ctx.template_manager);
         }
     );
-    
+
     /**
      * @brief Basic template management commands
-     * 
+     *
      * Includes: template save, template load, template info, template delete
      */
     commands.emplace_back(
         // Matcher for basic template commands
-        [](const std::string& input) { 
-            return prefix_match(input, "template save ") || 
+        [](const std::string& input) {
+            return prefix_match(input, "template save ") ||
                    prefix_match(input, "template load ") ||
                    prefix_match(input, "template info ") ||
                    prefix_match(input, "template delete ");
@@ -999,17 +1000,17 @@ void run_interactive() {
                 , ctx.template_manager, ctx.template_validator);
         }
     );
-    
+
     /**
      * @brief Template variable management commands
-     * 
-     * Includes: template setvar, template vars, template clearvars, 
+     *
+     * Includes: template setvar, template vars, template clearvars,
      * template vars [name], template setvars
      */
     commands.emplace_back(
         // Matcher for variable management commands
-        [](const std::string& input) { 
-            return prefix_match(input, "template setvar ") || 
+        [](const std::string& input) {
+            return prefix_match(input, "template setvar ") ||
                    exact_match(input, "template vars") ||
                    exact_match(input, "template clearvars") ||
                    prefix_match(input, "template vars ") ||
@@ -1020,10 +1021,10 @@ void run_interactive() {
             return handle_variable_commands(input, ctx.current_query, ctx.current_variables, ctx.template_manager);
         }
     );
-    
+
     /**
      * @brief Template instantiation command
-     * 
+     *
      * Handles: template use [name]
      */
     commands.emplace_back(
@@ -1035,16 +1036,16 @@ void run_interactive() {
                 , ctx.template_manager, ctx.template_validator);
         }
     );
-    
+
     /**
      * @brief Template inheritance commands
-     * 
+     *
      * Includes: template inherit, template parents
      */
     commands.emplace_back(
         // Matcher for template inheritance commands
-        [](const std::string& input) { 
-            return prefix_match(input, "template inherit ") || 
+        [](const std::string& input) {
+            return prefix_match(input, "template inherit ") ||
                    prefix_match(input, "template parents ");
         },
         // Handler delegates to template_inheritance implementation
@@ -1052,16 +1053,16 @@ void run_interactive() {
             return handle_template_inheritance(input, ctx.current_query, ctx.template_manager, ctx.template_validator);
         }
     );
-    
+
     /**
      * @brief Template validation commands
-     * 
+     *
      * Includes: template validate, template validateall
      */
     commands.emplace_back(
         // Matcher for template validation commands
-        [](const std::string& input) { 
-            return prefix_match(input, "template validate ") || 
+        [](const std::string& input) {
+            return prefix_match(input, "template validate ") ||
                    exact_match(input, "template validateall");
         },
         // Handler delegates to template_validation implementation
@@ -1069,16 +1070,16 @@ void run_interactive() {
             return handle_template_validation(input, ctx.template_manager, ctx.template_validator);
         }
     );
-    
+
     /**
      * @brief Template documentation commands
-     * 
+     *
      * Includes: template docs, template docsall, template export
      */
     commands.emplace_back(
         // Matcher for template documentation commands
-        [](const std::string& input) { 
-            return prefix_match(input, "template docs ") || 
+        [](const std::string& input) {
+            return prefix_match(input, "template docs ") ||
                    exact_match(input, "template docsall") ||
                    prefix_match(input, "template export ");
         },
@@ -1090,7 +1091,7 @@ void run_interactive() {
 
     /**
      * @brief Main command processing loop
-     * 
+     *
      * Reads user input, dispatches to appropriate command handler, and
      * updates the current query when input doesn't match any commands.
      */
@@ -1103,7 +1104,7 @@ void run_interactive() {
         if (line == "exit" || line == "quit") {
             break;
         }
-        
+
         // Dispatch to command handlers
         bool handled = false;
         for (const auto& [matcher, handler] : commands) {
@@ -1113,7 +1114,7 @@ void run_interactive() {
                 break;  // Stop after the first matching handler
             }
         }
-        
+
         // Default behavior: treat input as query content
         if (!handled) {
             // Add the line to the current query
@@ -1129,30 +1130,30 @@ void run_interactive() {
 bool process_file(const std::string& input_file, const std::string& output_file, bool include_header) {
     try {
         // Always show which file is being processed - useful for users
-        std::cout << "Processing file: " << input_file << std::endl;
+        UserOutputManager::info("Processing file: ", input_file);
 
         const std::string result = QueryProcessor::compile_file(input_file);
 
         if (output_file.empty()) {
             if (include_header) {
                 // Standard output with headers
-                std::cout << "\nCompiled Query\n";
-                std::cout << "==============\n\n";
-                std::cout << result << std::endl;
+                UserOutputManager::info("\nCompiled Query");
+                UserOutputManager::info("==============\n");
+                UserOutputManager::info(result);
             } else {
                 // Clean output: just the query without headers (default)
-                std::cout << result << std::endl;
+                UserOutputManager::info(result);
             }
         } else {
             util::write_file(output_file, result);
             if (include_header) {
-                std::cout << "Compiled query written to " << output_file << std::endl;
+                UserOutputManager::info("Compiled query written to ", output_file);
                 Logger::getInstance().log(LogLevel::INFO, "Compiled query written to ", output_file);
             }
         }
         return true;
     } catch (const std::exception& e) {
-        std::cerr << "Error processing file: " << e.what() << std::endl;
+        UserOutputManager::error("Error processing file: ", e.what());
         Logger::getInstance().log(LogLevel::ERROR, "Error processing file: ", e.what());
         return false;
     }
@@ -1164,22 +1165,22 @@ ApiClientConfig prepare_api_config(const std::string& model, const std::string& 
 
     // Load the configuration
     ApiClientConfig config = ApiClientConfig::load_from_default_locations();
-    
+
     // Override with command-line arguments
     if (!model.empty()) {
         config.set_model(model);
         Logger::getInstance().log(LogLevel::INFO, "Using model: ", model);
     }
-    
+
     if (!output_dir.empty()) {
         config.set_output_directory(output_dir);
         Logger::getInstance().log(LogLevel::INFO, "Output directory: ", output_dir);
     }
-    
+
     config.set_overwrite_existing_files(overwrite);
     config.set_create_missing_directories(create_dirs);
     config.set_no_save_mode(no_save);
-    
+
     return config;
 }
 
@@ -1195,17 +1196,17 @@ std::string compile_query_for_api(const std::string& input_file) {
 // Submit a compiled query to the API
 ApiResponse submit_to_api(const std::string& compiled_query, ApiClientConfig config) {
     Logger::getInstance().log(LogLevel::INFO, "Submitting to Claude API...");
-    std::cout << "Submitting to Claude API (model: " << config.get_model() << ")..." << std::endl;
-    
+    UserOutputManager::info("Submitting to Claude API (model: ", config.get_model(), ")...");
+
     ApiClient api_client(std::move(config));
     ApiResponse response = api_client.submit_query(compiled_query);
-    
+
     if (!response.m_success) {
         Logger::getInstance().log(LogLevel::ERROR, "API request failed: ", response.m_error_message);
-        std::cerr << "API request failed: " << response.m_error_message << std::endl;
+        UserOutputManager::error("API request failed: ", response.m_error_message);
     } else {
         Logger::getInstance().log(LogLevel::INFO, "API request successful");
-        std::cout << "API request successful" << std::endl;
+        UserOutputManager::info("API request successful");
     }
     return response;
 }
@@ -1214,13 +1215,13 @@ ApiResponse submit_to_api(const std::string& compiled_query, ApiClientConfig con
 std::vector<GeneratedFile> process_api_response(const ApiResponse& response, ApiClientConfig config) {
     ResponseProcessor processor(std::move(config));
     std::vector<GeneratedFile> files = processor.process_response(response.m_raw_response);
-    
+
     Logger::getInstance().log(LogLevel::INFO, "Generated ", files.size(), " files:");
-    std::cout << "Generated " << files.size() << " files:" << std::endl;
-    
+    UserOutputManager::info("Generated ", std::to_string(files.size()), " files:");
+
     for (const auto& file : files) {
         Logger::getInstance().log(LogLevel::INFO, "- ", file.m_filename);
-        std::cout << "  - " << file.m_filename << std::endl;
+        UserOutputManager::info("  - ", file.m_filename);
     }
     return files;
 }
@@ -1230,22 +1231,22 @@ void save_generated_files(const std::vector<GeneratedFile>& files, const ApiClie
     // Skip saving if no-save mode is enabled
     if (config.no_save_mode()) {
         Logger::getInstance().log(LogLevel::INFO, "Files not saved (--no-save option used)");
-        std::cout << "Files not saved (--no-save option used)" << std::endl;
+        UserOutputManager::info("Files not saved (--no-save option used)");
         return;
     }
-    
+
     // Save each file
     for (const auto& file : files) {
         save_generated_file(file, config.get_output_directory(), config);
     }
-    
+
     // Log where files were saved
     if (!config.get_output_directory().empty()) {
         Logger::getInstance().log(LogLevel::INFO, "Files saved to ", config.get_output_directory());
-        std::cout << "Files saved to " << config.get_output_directory() << std::endl;
+        UserOutputManager::info("Files saved to ", config.get_output_directory());
     } else {
         Logger::getInstance().log(LogLevel::INFO, "Files saved to current directory");
-        std::cout << "Files saved to current directory" << std::endl;
+        UserOutputManager::info("Files saved to current directory");
     }
 }
 
@@ -1255,26 +1256,26 @@ bool process_submit_command(const std::string& input_file, const std::string& ou
     try {
         // Prepare the configuration
         const ApiClientConfig config = prepare_api_config(model, output_dir, overwrite, create_dirs, no_save);
-        
+
         // Compile the query
         const std::string compiled_query = compile_query_for_api(input_file);
-        
+
         // Submit to API
         const ApiResponse response = submit_to_api(compiled_query, config);
         if (!response.m_success) {
             return false;
         }
-        
+
         // Process the response
         const std::vector<GeneratedFile> files = process_api_response(response, config);
-        
+
         // Save files
         save_generated_files(files, config);
-        
+
         return true;
     } catch (const std::exception& e) {
         Logger::getInstance().log(LogLevel::ERROR, "Error processing submit command: ", e.what());
-        std::cerr << "Error processing submit command: " << e.what() << std::endl;
+        UserOutputManager::error("Error processing submit command: ", e.what());
         return false;
     }
 }

--- a/src/cql/documentation_handler.cpp
+++ b/src/cql/documentation_handler.cpp
@@ -5,14 +5,15 @@
 #include "../../include/cql/cql.hpp"
 #include "../../include/cql/template_manager.hpp"
 #include "../../include/cql/error_context.hpp"
+#include "../../include/cql/user_output_manager.hpp"
 #include <iostream>
 
 namespace cql {
 
 int DocumentationHandler::handle_docs_command(int argc, char* argv[]) {
     if (argc < 3) {
-        std::cerr << "error: template name required" << std::endl;
-        std::cerr << "usage: cql --docs TEMPLATE_NAME" << std::endl;
+        UserOutputManager::error("template name required");
+        UserOutputManager::info("usage: cql --docs TEMPLATE_NAME");
         return CQL_ERROR;
     }
 
@@ -21,7 +22,7 @@ int DocumentationHandler::handle_docs_command(int argc, char* argv[]) {
     try {
         TemplateManager manager;
         const std::string docs = manager.generate_template_documentation(template_name);
-        std::cout << docs << std::endl;
+        UserOutputManager::info(docs);
     } catch (const std::exception& e) {
         // Preserve error context with template-specific information
         auto contextual_error = ErrorContextBuilder::from(e)
@@ -29,12 +30,12 @@ int DocumentationHandler::handle_docs_command(int argc, char* argv[]) {
             .template_name(template_name)
             .at(__FILE__ ":" + std::to_string(__LINE__))
             .build();
-        
+
         // Log with full context for debugging
         error_context_utils::log_contextual_exception(contextual_error);
-        
+
         // Display user-friendly message
-        std::cerr << "Error: " << contextual_error.get_user_summary() << std::endl;
+        UserOutputManager::error(contextual_error.get_user_summary());
         return CQL_ERROR;
     }
     return CQL_NO_ERROR;
@@ -44,19 +45,19 @@ int DocumentationHandler::handle_docs_all_command() {
     try {
         TemplateManager manager;
         const std::string docs = manager.generate_all_template_documentation();
-        std::cout << docs << std::endl;
+        UserOutputManager::info(docs);
     } catch (const std::exception& e) {
         // Preserve error context for documentation generation
         auto contextual_error = ErrorContextBuilder::from(e)
             .operation("generating documentation for all templates")
             .at(__FILE__ ":" + std::to_string(__LINE__))
             .build();
-        
+
         // Log with full context for debugging
         error_context_utils::log_contextual_exception(contextual_error);
-        
+
         // Display user-friendly message
-        std::cerr << "Error: " << contextual_error.get_user_summary() << std::endl;
+        UserOutputManager::error(contextual_error.get_user_summary());
         return CQL_ERROR;
     }
     return CQL_NO_ERROR;
@@ -64,8 +65,8 @@ int DocumentationHandler::handle_docs_all_command() {
 
 int DocumentationHandler::handle_export_command(int argc, char* argv[]) {
     if (argc < 3) {
-        std::cerr << "error: output path required" << std::endl;
-        std::cerr << "usage: cql --export OUTPUT_PATH [FORMAT]" << std::endl;
+        UserOutputManager::error("output path required");
+        UserOutputManager::info("usage: cql --export OUTPUT_PATH [FORMAT]");
         return CQL_ERROR;
     }
 
@@ -81,10 +82,10 @@ int DocumentationHandler::handle_export_command(int argc, char* argv[]) {
         TemplateManager manager;
 
         if (manager.export_documentation(output_path, format)) {
-            std::cout << "template documentation exported to " << output_path
-                      << " in " << format << " format" << std::endl;
+            UserOutputManager::success("template documentation exported to ", output_path,
+                      " in ", format, " format");
         } else {
-            std::cerr << "failed to export template documentation" << std::endl;
+            UserOutputManager::error("failed to export template documentation");
             return CQL_ERROR;
         }
     } catch (const std::exception& e) {
@@ -95,12 +96,12 @@ int DocumentationHandler::handle_export_command(int argc, char* argv[]) {
             .detail("format", format)
             .at(__FILE__ ":" + std::to_string(__LINE__))
             .build();
-        
+
         // Log with full context for debugging
         error_context_utils::log_contextual_exception(contextual_error);
-        
+
         // Display user-friendly message
-        std::cerr << "Error: " << contextual_error.get_user_summary() << std::endl;
+        UserOutputManager::error(contextual_error.get_user_summary());
         return CQL_ERROR;
     }
     return CQL_NO_ERROR;

--- a/src/cql/meta_prompt_handler.cpp
+++ b/src/cql/meta_prompt_handler.cpp
@@ -7,6 +7,7 @@
 #include "../../include/cql/cql.hpp"
 #include "../../include/cql/project_utils.hpp"
 #include "../../include/cql/input_validator.hpp"
+#include "../../include/cql/user_output_manager.hpp"
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -15,7 +16,7 @@ namespace cql {
 
 int MetaPromptHandler::handle_optimize_command(int argc, char* argv[]) {
     if (argc < 3) {
-        std::cerr << "Error: Input file required for --optimize option\n";
+        UserOutputManager::error("Input file required for --optimize option");
         print_optimize_usage();
         return CQL_ERROR;
     }
@@ -53,13 +54,13 @@ int MetaPromptHandler::handle_optimize_command(int argc, char* argv[]) {
             
             // Validate domain parameter for security
             if (domain.size() > InputValidator::MAX_CATEGORY_NAME_LENGTH) {
-                std::cerr << "Error: Domain name too long (max: " << InputValidator::MAX_CATEGORY_NAME_LENGTH << ")\n";
+                UserOutputManager::error("Domain name too long (max: ", InputValidator::MAX_CATEGORY_NAME_LENGTH, ")");
                 return CQL_ERROR;
             }
-            
+
             // Check for safe characters only
             if (!InputValidator::contains_only_safe_chars(domain, "a-zA-Z0-9_-")) {
-                std::cerr << "Error: Domain contains invalid characters. Only alphanumeric, underscore, and hyphen allowed.\n";
+                UserOutputManager::error("Domain contains invalid characters. Only alphanumeric, underscore, and hyphen allowed.");
                 return CQL_ERROR;
             }
         }
@@ -74,14 +75,14 @@ int MetaPromptHandler::handle_optimize_command(int argc, char* argv[]) {
             try {
                 int timeout_seconds = std::stoi(*timeout_value);
                 if (timeout_seconds < 1 || timeout_seconds > 600) { // 1 second to 10 minutes
-                    std::cerr << "Error: Timeout must be between 1 and 600 seconds\n";
+                    UserOutputManager::error("Timeout must be between 1 and 600 seconds");
                     return CQL_ERROR;
                 }
                 timeout_override = std::chrono::seconds{timeout_seconds};
-                Logger::getInstance().log(LogLevel::INFO, 
+                Logger::getInstance().log(LogLevel::INFO,
                     "Using custom timeout: ", timeout_seconds, " seconds");
             } catch (const std::exception& e) {
-                std::cerr << "Error: Invalid timeout value '" << *timeout_value << "'\n";
+                UserOutputManager::error("Invalid timeout value '", *timeout_value, "'");
                 return CQL_ERROR;
             }
         }
@@ -94,22 +95,22 @@ int MetaPromptHandler::handle_optimize_command(int argc, char* argv[]) {
         std::string query_content;
         try {
             query_content = util::read_file(secure_input_path);
-            
+
             // Validate query content size
             InputValidator::validate_query_length(query_content);
-            
+
         } catch (const std::exception& e) {
-            std::cerr << "Error reading input file: " << e.what() << std::endl;
+            UserOutputManager::error("Error reading input file: ", e.what());
             Logger::getInstance().log(LogLevel::ERROR,
                 "File read error: ", e.what());
             return CQL_ERROR;
         }
-        
+
         std::string compiled_query;
         try {
             compiled_query = QueryProcessor::compile(query_content);
         } catch (const std::exception& e) {
-            std::cerr << "Error compiling query: " << e.what() << std::endl;
+            UserOutputManager::error("Error compiling query: ", e.what());
             Logger::getInstance().log(LogLevel::ERROR,
                 "Query compilation error: ", e.what());
             return CQL_ERROR;
@@ -133,24 +134,24 @@ int MetaPromptHandler::handle_optimize_command(int argc, char* argv[]) {
         try {
             compiler = meta_prompt::HybridCompiler::create();
             if (!compiler) {
-                std::cerr << "Error: Failed to create meta-prompt compiler\n";
+                UserOutputManager::error("Failed to create meta-prompt compiler");
                 Logger::getInstance().log(LogLevel::ERROR,
                     "HybridCompiler creation failed");
                 return CQL_ERROR;
             }
         } catch (const std::exception& e) {
-            std::cerr << "Error creating compiler: " << e.what() << std::endl;
+            UserOutputManager::error("Error creating compiler: ", e.what());
             Logger::getInstance().log(LogLevel::ERROR,
                 "HybridCompiler creation exception: ", e.what());
             return CQL_ERROR;
         }
-        
+
         // Perform meta-prompt compilation with error handling
         meta_prompt::CompilationResult result;
         try {
             result = compiler->compile(compiled_query, flags);
         } catch (const std::exception& e) {
-            std::cerr << "Error during compilation: " << e.what() << std::endl;
+            UserOutputManager::error("Error during compilation: ", e.what());
             Logger::getInstance().log(LogLevel::ERROR,
                 "Meta-prompt compilation exception: ", e.what());
             return CQL_ERROR;
@@ -164,26 +165,26 @@ int MetaPromptHandler::handle_optimize_command(int argc, char* argv[]) {
             std::string output_file;
             if (argc > 3 && argv[3][0] != '-') {
                 output_file = argv[3];
-                
+
                 // Validate output file path
                 try {
                     // resolve_path_securely() already includes all validation from validate_file_path()
                     std::string secure_output_path = InputValidator::resolve_path_securely(output_file);
-                    
+
                     // Validate response size before writing
                     InputValidator::validate_response_size(result.compiled_prompt);
-                    
+
                     util::write_file(secure_output_path, result.compiled_prompt);
-                    std::cout << "\nOptimized query written to: " 
-                              << InputValidator::sanitize_for_logging(secure_output_path) << std::endl;
-                              
+                    UserOutputManager::success("Optimized query written to: ",
+                              InputValidator::sanitize_for_logging(secure_output_path));
+
                 } catch (const SecurityValidationError& e) {
-                    std::cerr << "Security validation error for output file: " << e.what() << std::endl;
+                    UserOutputManager::error("Security validation error for output file: ", e.what());
                     Logger::getInstance().log(LogLevel::ERROR,
                         "Output file security validation failed: ", e.what());
                     return CQL_ERROR;
                 } catch (const std::exception& e) {
-                    std::cerr << "Error writing output file: " << e.what() << std::endl;
+                    UserOutputManager::error("Error writing output file: ", e.what());
                     Logger::getInstance().log(LogLevel::ERROR,
                         "Output file write error: ", e.what());
                     return CQL_ERROR;
@@ -192,11 +193,11 @@ int MetaPromptHandler::handle_optimize_command(int argc, char* argv[]) {
                 try {
                     // Validate response size before displaying
                     InputValidator::validate_response_size(result.compiled_prompt);
-                    
-                    std::cout << "\n--- OPTIMIZED QUERY ---\n";
-                    std::cout << result.compiled_prompt << std::endl;
+
+                    UserOutputManager::info("\n--- OPTIMIZED QUERY ---");
+                    UserOutputManager::info(result.compiled_prompt);
                 } catch (const SecurityValidationError& e) {
-                    std::cerr << "Response too large to display: " << e.what() << std::endl;
+                    UserOutputManager::error("Response too large to display: ", e.what());
                     Logger::getInstance().log(LogLevel::ERROR,
                         "Response size validation failed: ", e.what());
                     return CQL_ERROR;
@@ -204,17 +205,17 @@ int MetaPromptHandler::handle_optimize_command(int argc, char* argv[]) {
             }
             return CQL_NO_ERROR;
         } else {
-            std::cerr << "Meta-prompt compilation failed\n";
+            UserOutputManager::error("Meta-prompt compilation failed");
             return CQL_ERROR;
         }
         
     } catch (const SecurityValidationError& e) {
-        std::cerr << "Security validation error: " << e.what() << std::endl;
+        UserOutputManager::error("Security validation error: ", e.what());
         Logger::getInstance().log(LogLevel::ERROR,
             "Security validation failed: ", e.what());
         return CQL_ERROR;
     } catch (const std::exception& e) {
-        std::cerr << "Error during meta-prompt compilation: " << e.what() << std::endl;
+        UserOutputManager::error("Error during meta-prompt compilation: ", e.what());
         Logger::getInstance().log(LogLevel::ERROR,
             "Meta-prompt compilation exception: ", e.what());
         return CQL_ERROR;
@@ -231,8 +232,8 @@ meta_prompt::CompilationMode MetaPromptHandler::parse_compilation_mode(const std
     } else if (mode_str == "ASYNC_LLM") {
         return meta_prompt::CompilationMode::ASYNC_LLM;
     } else {
-        std::cerr << "Warning: Unknown compilation mode '" << mode_str 
-                  << "', using CACHED_LLM as default\n";
+        UserOutputManager::warning("Unknown compilation mode '", mode_str,
+                  "', using CACHED_LLM as default");
         return meta_prompt::CompilationMode::CACHED_LLM;
     }
 }
@@ -247,8 +248,8 @@ meta_prompt::OptimizationGoal MetaPromptHandler::parse_optimization_goal(const s
     } else if (goal_str == "DOMAIN_SPECIFIC") {
         return meta_prompt::OptimizationGoal::DOMAIN_SPECIFIC;
     } else {
-        std::cerr << "Warning: Unknown optimization goal '" << goal_str 
-                  << "', using BALANCED as default\n";
+        UserOutputManager::warning("Unknown optimization goal '", goal_str,
+                  "', using BALANCED as default");
         return meta_prompt::OptimizationGoal::BALANCED;
     }
 }
@@ -256,54 +257,57 @@ meta_prompt::OptimizationGoal MetaPromptHandler::parse_optimization_goal(const s
 void MetaPromptHandler::display_compilation_result(const meta_prompt::CompilationResult& result,
                                                   bool show_metrics,
                                                   bool show_validation) {
-    std::cout << "\n=== META-PROMPT COMPILATION RESULTS ===" << std::endl;
-    
+    UserOutputManager::info("\n=== META-PROMPT COMPILATION RESULTS ===");
+
     if (result.success) {
-        std::cout << "Status: ✅ SUCCESS" << std::endl;
-        
+        UserOutputManager::success("Status: ✅ SUCCESS");
+
         // Basic info
-        std::cout << "Original length: " << result.original_query.length() << " characters" << std::endl;
-        std::cout << "Optimized length: " << result.compiled_prompt.length() << " characters" << std::endl;
-        
+        UserOutputManager::info("Original length: ", result.original_query.length(), " characters");
+        UserOutputManager::info("Optimized length: ", result.compiled_prompt.length(), " characters");
+
         if (!result.original_query.empty()) {
-            double reduction = ((double)(result.original_query.length() - result.compiled_prompt.length()) 
+            double reduction = ((double)(result.original_query.length() - result.compiled_prompt.length())
                               / result.original_query.length()) * 100.0;
-            std::cout << "Size change: " << std::fixed << std::setprecision(1) << reduction << "%" << std::endl;
+            std::ostringstream oss;
+            oss << std::fixed << std::setprecision(1) << reduction << "%";
+            UserOutputManager::info("Size change: ", oss.str());
         }
-        
+
         // Show metrics if requested
         if (show_metrics) {
-            std::cout << "\n" << format_metrics(result.metrics) << std::endl;
+            UserOutputManager::info("\n", format_metrics(result.metrics));
         }
-        
-        // Show validation if requested  
+
+        // Show validation if requested
         if (show_validation) {
-            std::cout << "\n" << format_validation(result.validation_result) << std::endl;
+            UserOutputManager::info("\n", format_validation(result.validation_result));
         }
-        
+
     } else {
-        std::cout << "Status: ❌ FAILED" << std::endl;
-        std::cout << "Error: " << result.error_message << std::endl;
-        
+        UserOutputManager::error("Status: ❌ FAILED");
+        UserOutputManager::error("Error: ", result.error_message);
+
         if (show_metrics) {
-            std::cout << "\n" << format_metrics(result.metrics) << std::endl;
+            UserOutputManager::info("\n", format_metrics(result.metrics));
         }
     }
 }
 
 void MetaPromptHandler::print_optimize_usage() {
-    std::cout << "Usage: cql --optimize INPUT_FILE [OUTPUT_FILE] [OPTIONS]\n\n";
-    std::cout << "Options:\n";
-    std::cout << "  --mode <mode>           Compilation mode (LOCAL_ONLY, CACHED_LLM, FULL_LLM, ASYNC_LLM)\n";
-    std::cout << "  --goal <goal>           Optimization goal (REDUCE_TOKENS, IMPROVE_ACCURACY, BALANCED, DOMAIN_SPECIFIC)\n";
-    std::cout << "  --domain <domain>       Domain context for optimization\n";
-    std::cout << "  --timeout <seconds>     Network timeout in seconds (1-600, default: 120)\n";
-    std::cout << "  --show-metrics          Display detailed compilation metrics\n";
-    std::cout << "  --show-validation       Display semantic validation results\n\n";
-    std::cout << "Examples:\n";
-    std::cout << "  cql --optimize query.cql                    # Basic optimization\n";
-    std::cout << "  cql --optimize query.cql --goal REDUCE_TOKENS --show-metrics\n";
-    std::cout << "  cql --optimize query.cql optimized.cql --mode FULL_LLM --domain software --timeout 60\n";
+    UserOutputManager::info(
+        "Usage: cql --optimize INPUT_FILE [OUTPUT_FILE] [OPTIONS]\n\n"
+        "Options:\n"
+        "  --mode <mode>           Compilation mode (LOCAL_ONLY, CACHED_LLM, FULL_LLM, ASYNC_LLM)\n"
+        "  --goal <goal>           Optimization goal (REDUCE_TOKENS, IMPROVE_ACCURACY, BALANCED, DOMAIN_SPECIFIC)\n"
+        "  --domain <domain>       Domain context for optimization\n"
+        "  --timeout <seconds>     Network timeout in seconds (1-600, default: 120)\n"
+        "  --show-metrics          Display detailed compilation metrics\n"
+        "  --show-validation       Display semantic validation results\n\n"
+        "Examples:\n"
+        "  cql --optimize query.cql                    # Basic optimization\n"
+        "  cql --optimize query.cql --goal REDUCE_TOKENS --show-metrics\n"
+        "  cql --optimize query.cql optimized.cql --mode FULL_LLM --domain software --timeout 60");
 }
 
 std::string MetaPromptHandler::format_metrics(const meta_prompt::CompilationMetrics& metrics) {


### PR DESCRIPTION
## Summary
This PR completes **Phase 4** of the logging system enhancement roadmap by updating all remaining files to use `UserOutputManager` instead of direct `std::cout`/`std::cerr` calls.

## Changes Made

### Core Files Updated
- **cli.cpp**: Replaced ~138 `std::cout` calls with `UserOutputManager::info()` and `std::cerr` with `UserOutputManager::error()`
- **meta_prompt_handler.cpp**: Updated all user-facing output to use `UserOutputManager`
- **template_operations.cpp**: Converted all output calls to `UserOutputManager` methods
- **documentation_handler.cpp**: Updated to use `UserOutputManager` for all user messages

### Test Updates
- **test_meta_prompt_cli.cpp**: Updated test fixture to use callback-based `UserOutput` instead of capturing `std::cout` directly

## Benefits
✅ **Consistent Output Handling**: All user-facing messages now go through `UserOutputManager`  
✅ **Better Separation**: Clear distinction between user messages (`UserOutputManager`) and debug logging (`Logger`)  
✅ **Easier Testing**: Callback-based output capture for cleaner unit tests  
✅ **Improved Maintainability**: Single source of truth for user output formatting  
✅ **Foundation for Future Enhancements**: Enables future features like output redirection, formatting options, etc.

## Test Results
All tests passing:
- ✅ **223 tests passed**
- ⏭️ **7 tests skipped** (Live API integration tests)
- 🔒 **1 test disabled** (Integration test)

## Pattern Applied
```cpp
// Before (Phase 3 and earlier):
std::cout << "Message" << std::endl;
std::cerr << "Error: " << error << std::endl;

// After (Phase 4):
UserOutputManager::info("Message");
UserOutputManager::error("Error: ", error);
```

## Phase 4 Roadmap Status
- ✅ Phase 1: File-only logging by default (PR #44 - Merged)
- ✅ Phase 2: Separate user output from debug logging (PR #45 - Merged)
- 📋 Phase 3: Enhanced file logger configuration (Pending)
- ✅ **Phase 4: Clean up mixed output patterns** (This PR)
- 📋 Phase 5: Multi-logger with independent level control (Pending)
- 📋 Phase 6: Documentation and examples (Pending)

## Related PRs
- PR #44: Phase 1 - File-only logging by default
- PR #45: Phase 2 - Separate user output from debug logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)